### PR TITLE
Add extensible options builder for event registration

### DIFF
--- a/Blouppy.Events.Tests/EventPublishers/ForeachAwaitEventPublisherTests.cs
+++ b/Blouppy.Events.Tests/EventPublishers/ForeachAwaitEventPublisherTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Blouppy.Events.Tests.EventPublishers;
 
-public sealed class ForeachAwaitPublisherTests
+public sealed class ForeachAwaitEventPublisherTests
 {
     [Fact]
     public async Task Should_execute_handlers_sequentially()
@@ -18,7 +18,7 @@ public sealed class ForeachAwaitPublisherTests
         var handler2 = new DelayedHandler(delay);
 
         var serviceProvider = ServiceProviderBuilder.Build(x => x
-            .AddEventPublisher<ForeachAwaitPublisher>()
+            .AddEventPublisher<ForeachAwaitEventPublisher>()
             .AddHandler(handler1)
             .AddHandler(handler2)
         );

--- a/Blouppy.Events.Tests/EventPublishers/TaskWhenAllPublisherTests.cs
+++ b/Blouppy.Events.Tests/EventPublishers/TaskWhenAllPublisherTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Blouppy.Events.Tests.EventPublishers;
 
-public sealed class TaskWhenAllPublisherTests
+public sealed class TaskWhenAllEventPublisherTests
 {
     [Fact]
     public async Task Should_execute_handlers_in_parallel()
@@ -18,7 +18,7 @@ public sealed class TaskWhenAllPublisherTests
         var handler2 = new DelayedHandler(delay);
 
         var serviceProvider = ServiceProviderBuilder.Build(x => x
-            .AddEventPublisher<TaskWhenAllPublisher>()
+            .AddEventPublisher<TaskWhenAllEventPublisher>()
             .AddHandler(handler1)
             .AddHandler(handler2)
         );

--- a/Blouppy.Events.Tests/PublisherTests.cs
+++ b/Blouppy.Events.Tests/PublisherTests.cs
@@ -13,7 +13,7 @@ public sealed class PublisherTests
     {
         // Arrange
         var serviceProvider = ServiceProviderBuilder.Build(x => x
-            .AddEventPublisher<ForeachAwaitPublisher>()
+            .AddEventPublisher<ForeachAwaitEventPublisher>()
             .AddMockedEventHandler<Event1>()
         );
 
@@ -35,7 +35,7 @@ public sealed class PublisherTests
     {
         // Arrange
         var serviceProvider = ServiceProviderBuilder.Build(x => x
-            .AddEventPublisher<ForeachAwaitPublisher>()
+            .AddEventPublisher<ForeachAwaitEventPublisher>()
             .AddMockedEventHandler<Event1>()
             .AddMockedEventHandler<Event1>()
         );
@@ -60,7 +60,7 @@ public sealed class PublisherTests
     {
         // Arrange
         var serviceProvider = ServiceProviderBuilder.Build(x => x
-            .AddEventPublisher<ForeachAwaitPublisher>()
+            .AddEventPublisher<ForeachAwaitEventPublisher>()
         );
         
         var sut = BuildSut(serviceProvider);
@@ -85,7 +85,7 @@ public sealed class PublisherTests
 
         // Arrange
         var serviceProvider = ServiceProviderBuilder.Build(x => x
-            .AddEventPublisher<ForeachAwaitPublisher>()
+            .AddEventPublisher<ForeachAwaitEventPublisher>()
             .AddHandler(handler1)
             .AddHandler(handler1Bis)
             .AddHandler(handler2)

--- a/Blouppy.Events/BlouppyEventsOptionsBuilder.cs
+++ b/Blouppy.Events/BlouppyEventsOptionsBuilder.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Blouppy.Events.EventPublishers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Blouppy.Events;
+
+public sealed class BlouppyEventsOptionsBuilder
+{
+    internal List<Assembly> AssembliesToScan { get; } = [];
+    
+    /// <summary>
+    /// Type of event publisher strategy to register. Defaults to <see cref="ForeachAwaitEventPublisher"/>
+    /// </summary>
+    public Type EventPublisherType { get; set; } = typeof(ForeachAwaitEventPublisher);
+    
+    /// <summary>
+    /// Service lifetime to register services. Default value is <see cref="ServiceLifetime.Scoped"/>
+    /// </summary>
+    public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Scoped;
+
+    /// <summary>
+    /// Register handlers from assemblies.
+    /// </summary>
+    /// <param name="assembliesToScan">Assemblies to scan</param>
+    /// <returns>This</returns>
+    public BlouppyEventsOptionsBuilder RegisterServicesFromAssemblies(
+        params Assembly[] assembliesToScan)
+    {
+        AssembliesToScan.AddRange(assembliesToScan);
+
+        return this;
+    }
+}

--- a/Blouppy.Events/EventHandlers/EventHandlerExecutor.cs
+++ b/Blouppy.Events/EventHandlers/EventHandlerExecutor.cs
@@ -2,6 +2,6 @@ using Blouppy.Events.Abstractions;
 
 namespace Blouppy.Events.EventHandlers;
 
-internal record EventHandlerExecutor(
+public record EventHandlerExecutor(
     object HandlerInstance, 
     Func<IEvent, CancellationToken, Task> HandlerCallback);

--- a/Blouppy.Events/EventHandlers/EventHandlerWrapper.cs
+++ b/Blouppy.Events/EventHandlers/EventHandlerWrapper.cs
@@ -14,7 +14,9 @@ internal sealed class EventHandlerWrapper<TEvent> : IEventHandlerWrapper
     {
         var handlers = serviceProvider
             .GetServices<IEventHandler<TEvent>>()
-            .Select(static x => new EventHandlerExecutor(x, (theEvent, theToken) => x.HandleAsync((TEvent)theEvent, theToken)));
+            .Select(static x => new EventHandlerExecutor(
+                HandlerInstance: x,
+                HandlerCallback: (@event, token) => x.HandleAsync((TEvent)@event, token)));
 
         return publish(handlers, @event, cancellationToken);
     }

--- a/Blouppy.Events/EventPublishers/ForeachAwaitEventPublisher.cs
+++ b/Blouppy.Events/EventPublishers/ForeachAwaitEventPublisher.cs
@@ -11,7 +11,7 @@ namespace Blouppy.Events.EventPublishers;
 /// }
 /// </code>
 /// </summary>
-internal sealed class ForeachAwaitPublisher : IEventPublisher
+public sealed class ForeachAwaitEventPublisher : IEventPublisher
 {
     public async Task PublishAsync(
         IEnumerable<EventHandlerExecutor> handlerExecutors, 

--- a/Blouppy.Events/EventPublishers/IEventPublisher.cs
+++ b/Blouppy.Events/EventPublishers/IEventPublisher.cs
@@ -3,7 +3,7 @@ using Blouppy.Events.EventHandlers;
 
 namespace Blouppy.Events.EventPublishers;
 
-internal interface IEventPublisher
+public interface IEventPublisher
 {
     Task PublishAsync(IEnumerable<EventHandlerExecutor> handlerExecutors, IEvent @event, CancellationToken cancellationToken);
 }

--- a/Blouppy.Events/EventPublishers/TaskWhenAllEventPublisher.cs
+++ b/Blouppy.Events/EventPublishers/TaskWhenAllEventPublisher.cs
@@ -13,7 +13,7 @@ namespace Blouppy.Events.EventPublishers;
 /// return Task.WhenAll(tasks);
 /// </code>
 /// </summary>
-internal sealed class TaskWhenAllPublisher : IEventPublisher
+public sealed class TaskWhenAllEventPublisher : IEventPublisher
 {
     public Task PublishAsync(
         IEnumerable<EventHandlerExecutor> handlerExecutors, 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Add extensible options builder for event registration

Introduce `BlouppyEventsOptionsBuilder` to simplify and unify handler and mediator registration with customizable options like service lifetime and event publishing strategy. Updated the public API to support these options and made `IEventPublisher` public for broader usage.